### PR TITLE
travis: PHP 7.0 nightly added + cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:
-  - travis_retry composer self-update
-  - travis_retry composer install --prefer-source --no-interaction --dev
+  - travis_retry composer install --prefer-source --no-interaction
   
 script:
   - vendor/bin/phpspec run -v


### PR DESCRIPTION
- no need to update composer (possible incompatibility with local or other projects run by Travis)
-  `--dev` option is on by default for couple of months