### PR TITLE
Fix bypassing keywords as sting to method setKeywords

### DIFF
--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -175,7 +175,7 @@ class SEOMeta implements MetaTagsContract
     public function setKeywords($keywords)
     {
         if (!is_array($keywords)):
-            $keywords = explode(', ', $this->keywords);
+            $keywords = explode(', ', $keywords);
         endif;
 
         // clean keywords


### PR DESCRIPTION
```php
SEOMeta::setTitle($meta->title)
    ->setDescription($meta->description)
    ->setKeywords($meta->keywords);
```
In case when $meta->keywords is a string - raising an error:
> ErrorException in SEOMeta.php line 178: explode() expects parameter 2 to be string, array given