### PR TITLE
typofix 'seperator' to 'separator'

### DIFF
--- a/README-en_US.md
+++ b/README-en_US.md
@@ -279,7 +279,7 @@ class CommomController extends Controller
 
 #### API (SEOMeta)
 ```php
-SEOMeta::SetTitleSeparator($seperator);
+SEOMeta::SetTitleSeparator($separator);
 SEOMeta::setTitle($title);
 SEOMeta::setDescription($description);
 SEOMeta::setKeywords($keywords);
@@ -296,7 +296,7 @@ SEOMeta::setTitle($title)
 // Retrieving data
 SEOMeta::getTitle();
 SEOMeta::getTitleSession();
-SEOMeta::getTitleSeperator();
+SEOMeta::getTitleSeparator();
 SEOMeta::getKeywords();
 SEOMeta::getDescription();
 SEOMeta::reset();

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ class CommomController extends Controller
 
 ##### API (SEOMeta)
 ```php
-SEOMeta::SetTitleSeparator($seperator);
+SEOMeta::SetTitleSeparator($separator);
 SEOMeta::setTitle($title);
 SEOMeta::setDescription($description);
 SEOMeta::setKeywords($keywords);
@@ -299,7 +299,7 @@ SEOMeta::setTitle($title)
 // Obtendo os dados
 SEOMeta::getTitle();
 SEOMeta::getTitleSession();
-SEOMeta::getTitleSeperator();
+SEOMeta::getTitleSeparator();
 SEOMeta::getKeywords();
 SEOMeta::getDescription();
 SEOMeta::reset();

--- a/src/SEOTools/Contracts/MetaTags.php
+++ b/src/SEOTools/Contracts/MetaTags.php
@@ -27,7 +27,7 @@ interface MetaTags
     public function setTitle($title);
 
     /**
-     * Set the title seperator.
+     * Set the title separator.
      *
      * @param string $separator
      *
@@ -98,11 +98,11 @@ interface MetaTags
     public function getTitleSession();
 
     /**
-     * Get the title seperator that was set.
+     * Get the title separator that was set.
      *
      * @return string
      */
-    public function getTitleSeperator();
+    public function getTitleSeparator();
 
     /**
      * Get all metatags

--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -20,11 +20,11 @@ class SEOMeta implements MetaTagsContract
     protected $title_session;
 
     /**
-     * The title tag seperator.
+     * The title tag separator.
      *
      * @var array
      */
-    protected $title_seperator;
+    protected $title_separator;
 
     /**
      * The meta description.
@@ -145,7 +145,7 @@ class SEOMeta implements MetaTagsContract
      */
     public function setTitleSeparator($separator)
     {
-        $this->title_seperator = $separator;
+        $this->title_separator = $separator;
 
         return $this;
     }
@@ -267,9 +267,9 @@ class SEOMeta implements MetaTagsContract
      *
      * @return string
      */
-    public function getTitleSeperator()
+    public function getTitleSeparator()
     {
-        return $this->title_seperator ?: $this->config->get('defaults.separator', ' - ');
+        return $this->title_separator ?: $this->config->get('defaults.separator', ' - ');
     }
 
     /**
@@ -328,7 +328,7 @@ class SEOMeta implements MetaTagsContract
     {
         $default = $this->config->get('defaults.title', null);
 
-        return (empty($default)) ? $title : $title . $this->getTitleSeperator() . $default;
+        return (empty($default)) ? $title : $title . $this->getTitleSeparator() . $default;
     }
 
     /**


### PR DESCRIPTION
I found 'seperator' on the code, but i think 'separator' is much better. :)