### PR TITLE
Add default config for canonical

### DIFF
--- a/.idea/composerJson.xml
+++ b/.idea/composerJson.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ComposerJsonPluginSettings">
-    <unboundedVersionInspectionSettings>
-      <excludedPackages />
-    </unboundedVersionInspectionSettings>
-    <customRepositories />
-  </component>
-</project>

--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -476,9 +476,9 @@ class SEOMeta implements MetaTagsContract
      */
     public function getCanonical()
     {
-        $canonical_config = $this->config->get('defaults.canonical', null);
+        $canonical_config = $this->config->get('defaults.canonical', false);
 
-        return $this->canonical ?: (($canonical_config === '') ? app('url')->current() : $canonical_config);
+        return $this->canonical ?: (($canonical_config === null) ? app('url')->current() : $canonical_config);
     }
 
     /**

--- a/src/resources/config/seotools.php
+++ b/src/resources/config/seotools.php
@@ -10,7 +10,7 @@ return [
             'description'  => 'For those who helped create the Genki Dama', // set false to total remove
             'separator'    => ' - ',
             'keywords'     => [],
-            'canonical'    => false, // Leave blank for using Url::current(), set false to total remove
+            'canonical'    => false, // Set null for using Url::current(), set false to total remove
         ],
 
         /*

--- a/src/resources/config/seotools.php
+++ b/src/resources/config/seotools.php
@@ -10,7 +10,7 @@ return [
             'description'  => 'For those who helped create the Genki Dama', // set false to total remove
             'separator'    => ' - ',
             'keywords'     => [],
-            'canonical'    => '', // Leave blank for using Url::current(), set false to total remove
+            'canonical'    => false, // Leave blank for using Url::current(), set false to total remove
         ],
 
         /*


### PR DESCRIPTION
Following the proposal on issue #55, a canonical default url is set using the `Url::current()` value.

Is not possible to use any bindings like `Url` facade or `app('url')` in config file, because aren't ready for usage at the time when config is loaded. 

If the canonical is leave blank  in config file the `app('url')->current()` is used. 
If is set to `false` or `null`  it will be omitted and if other value is set on config file or by the setters it will be used

> I use the app() helper instead of Url facade for make this change compatible with Laravel and Lumen