### PR TITLE
Corrigindo parametros padrões de TwitterCard

### DIFF
--- a/src/SEOTools/Contracts/TwitterCards.php
+++ b/src/SEOTools/Contracts/TwitterCards.php
@@ -7,7 +7,7 @@ interface TwitterCards
     /**
      * @param array $defaults
      */
-    public function __construct(array $defaults);
+    public function __construct(array $defaults = []);
 
     /**
      * @return string

--- a/src/SEOTools/TwitterCards.php
+++ b/src/SEOTools/TwitterCards.php
@@ -29,7 +29,7 @@ class TwitterCards implements TwitterCardsContract
     /**
      * @param array $defaults
      */
-    public function __construct(array $defaults)
+    public function __construct(array $defaults = [])
     {
         $this->values = $defaults;
     }


### PR DESCRIPTION
Padronizei os parametros da classe TwitterCards para ficar iguais as outras classes, dessa forma não quebra o teste unitário dela