### PR TITLE
Added Optional Minify Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ class CommomController extends Controller
 
 ### In Your View
 
+> **Pro Tip**: Pass the parameter `true` to get minified code and reduce filesize.
+
 ```html
 <html>
 <head>
@@ -373,6 +375,10 @@ class CommomController extends Controller
 	{!! Twitter::generate() !!}
 	    <!-- OR -->
 	{!! SEO::generate() !!}
+	
+	  <!-- MINIFIED -->
+	{!! SEO::generate(true) !!}
+	
 
 	    <!-- LUMEN -->
 	{!! app('seotools')->generate() !!}

--- a/src/SEOTools/Contracts/MetaTags.php
+++ b/src/SEOTools/Contracts/MetaTags.php
@@ -13,10 +13,12 @@ interface MetaTags
 
     /**
      * Generates meta tags.
+     * 
+     * @param bool $minify
      *
      * @return string
      */
-    public function generate();
+    public function generate($minify = false);
 
     /**
      * Set the title.

--- a/src/SEOTools/Contracts/OpenGraph.php
+++ b/src/SEOTools/Contracts/OpenGraph.php
@@ -11,10 +11,12 @@ interface OpenGraph
 
     /**
      * Generates open graph tags.
+     * 
+     * @param bool $minify
      *
      * @return string
      */
-    public function generate();
+    public function generate($minify = false);
 
     /**
      * Add or update property.

--- a/src/SEOTools/Contracts/SEOTools.php
+++ b/src/SEOTools/Contracts/SEOTools.php
@@ -71,8 +71,10 @@ interface SEOTools
 
     /**
      * Generate from all seo providers.
+     * 
+     * @param bool $minify
      *
      * @return string
      */
-    public function generate();
+    public function generate($minify = false);
 }

--- a/src/SEOTools/Contracts/TwitterCards.php
+++ b/src/SEOTools/Contracts/TwitterCards.php
@@ -10,9 +10,11 @@ interface TwitterCards
     public function __construct(array $defaults = []);
 
     /**
+     * @param bool $minify
+     * 
      * @return string
      */
-    public function generate();
+    public function generate($minify = false);
 
     /**
      * @param string       $key

--- a/src/SEOTools/OpenGraph.php
+++ b/src/SEOTools/OpenGraph.php
@@ -139,10 +139,12 @@ class OpenGraph implements OpenGraphContract
 
     /**
      * Generates open graph tags.
+     * 
+     * @param bool $minify
      *
      * @return string
      */
-    public function generate()
+    public function generate($minify = false)
     {
         $this->setupDefaults();
 
@@ -173,7 +175,7 @@ class OpenGraph implements OpenGraphContract
             );
         }
 
-        return $output;
+        return ($minify) ? str_replace(PHP_EOL, '', $output) : $output;
     }
 
     /**

--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -112,10 +112,12 @@ class SEOMeta implements MetaTagsContract
 
     /**
      * Generates meta tags.
+     * 
+     * @param bool $minify
      *
      * @return string
      */
-    public function generate()
+    public function generate($minify = false)
     {
         $this->loadWebMasterTags();
 
@@ -171,7 +173,7 @@ class SEOMeta implements MetaTagsContract
             $html[] = "<link rel=\"alternate\" hreflang=\"{$lang['lang']}\" href=\"{$lang['url']}\"/>";
         }
 
-        return implode(PHP_EOL, $html);
+        return ($minify) ? implode('', $html) : implode(PHP_EOL, $html);
     }
 
     /**

--- a/src/SEOTools/SEOTools.php
+++ b/src/SEOTools/SEOTools.php
@@ -112,10 +112,12 @@ class SEOTools implements SEOContract
 
     /**
      * Generate from all seo providers.
-     *
+     * 
+     * @param bool $minify
+     * 
      * @return string
      */
-    public function generate()
+    public function generate($minify = false)
     {
         $html = $this->metatags()->generate();
         $html .= PHP_EOL;
@@ -123,6 +125,6 @@ class SEOTools implements SEOContract
         $html .= PHP_EOL;
         $html .= $this->twitter()->generate();
 
-        return $html;
+        return ($minify) ? str_replace(PHP_EOL, '', $html) : $html;
     }
 }

--- a/src/SEOTools/TwitterCards.php
+++ b/src/SEOTools/TwitterCards.php
@@ -35,14 +35,16 @@ class TwitterCards implements TwitterCardsContract
     }
 
     /**
+     * @param bool $minify
+     * 
      * @return string
      */
-    public function generate()
+    public function generate($minify = false)
     {
         $this->eachValue($this->values);
         $this->eachValue($this->images, 'images');
 
-        return implode(PHP_EOL, $this->html);
+        return ($minify) ? implode('', $this->html) : implode(PHP_EOL, $this->html);
     }
 
     /**


### PR DESCRIPTION
Users can now pass the boolean `true` to any of the generate methods to receive minified code.

Ex:
``` html
{!! SEO::generate(true) !!}
```
returns all of the code on a single line.

This is a feature that should have been in the original release since page load speed is so important to SEO.