### PR TITLE
Add AMP html link

### DIFF
--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -510,7 +510,7 @@ class SEOMeta implements MetaTagsContract
     }
 
     /**
-     * Get the canonical URL.
+     * Get the AMP html URL.
      *
      * @return string
      */

--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -64,6 +64,13 @@ class SEOMeta implements MetaTagsContract
     protected $canonical;
 
     /**
+     * The AMP URL.
+     *
+     * @var string
+     */
+    protected $amphtml;
+
+    /**
      * The prev URL in pagination.
      *
      * @var string
@@ -126,6 +133,7 @@ class SEOMeta implements MetaTagsContract
         $keywords = $this->getKeywords();
         $metatags = $this->getMetatags();
         $canonical = $this->getCanonical();
+        $amphtml = $this->getAmpHtml();
         $prev = $this->getPrev();
         $next = $this->getNext();
         $languages = $this->getAlternateLanguages();
@@ -159,6 +167,10 @@ class SEOMeta implements MetaTagsContract
 
         if ($canonical) {
             $html[] = "<link rel=\"canonical\" href=\"{$canonical}\"/>";
+        }
+
+        if ($amphtml) {
+            $html[] = "<link rel=\"amphtml\" href=\"{$amphtml}\"/>";
         }
 
         if ($prev) {
@@ -337,6 +349,20 @@ class SEOMeta implements MetaTagsContract
     }
 
     /**
+     * Sets the AMP html URL.
+     *
+     * @param string $url
+     *
+     * @return MetaTagsContract
+     */
+    public function setAmpHtml($url)
+    {
+        $this->amphtml = $url;
+
+        return $this;
+    }
+
+    /**
      * Sets the prev URL.
      *
      * @param string $url
@@ -484,6 +510,16 @@ class SEOMeta implements MetaTagsContract
     }
 
     /**
+     * Get the canonical URL.
+     *
+     * @return string
+     */
+    public function getAmpHtml()
+    {
+        return $this->amphtml;
+    }
+
+    /**
      * Get the prev URL.
      *
      * @return string
@@ -525,10 +561,10 @@ class SEOMeta implements MetaTagsContract
         $this->next = null;
         $this->prev = null;
         $this->canonical = null;
+        $this->amphtml = null;
         $this->metatags = [];
         $this->keywords = [];
         $this->alternateLanguages = [];
-        $this->canonical = null;
     }
 
     /**

--- a/tests/SEOTools/SEOMetaTest.php
+++ b/tests/SEOTools/SEOMetaTest.php
@@ -169,6 +169,19 @@ class SEOMetaTest extends BaseTest
         $this->assertEquals($canonical, $this->seoMeta->getCanonical());
     }
 
+    public function test_set_amp()
+    {
+        $fullHeader = "<title>It's Over 9000!</title>";
+        $fullHeader .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
+        $fullHeader .= "<link rel=\"amphtml\" href=\"http://domain.com/amp\"/>";
+        $amphtml = 'http://domain.com/amp';
+
+        $this->seoMeta->setAmpHtml($amphtml);
+
+        $this->setRightAssertion($fullHeader);
+        $this->assertEquals($amphtml, $this->seoMeta->getAmpHtml());
+    }
+
     public function test_set_next()
     {
         $fullHeader = "<title>It's Over 9000!</title>";


### PR DESCRIPTION
Add an easy way to reference AMP pages:

```php
\SEOMeta::setAmpHtml('http://example.org/amp');
```

... which will output:
```html
<link rel="amphtml" href="http://example.org/amp"/>
```