### PR TITLE
i think full url better than current url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.phar
+.idea/
 vendor/
 composer.lock

--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -506,7 +506,7 @@ class SEOMeta implements MetaTagsContract
     {
         $canonical_config = $this->config->get('defaults.canonical', false);
 
-        return $this->canonical ?: (($canonical_config === null) ? app('url')->current() : $canonical_config);
+        return $this->canonical ?: (($canonical_config === null) ? app('url')->full() : $canonical_config);
     }
 
     /**


### PR DESCRIPTION
hi 
i think app('url')->full() is better than app('url')->current() in getCanonical because get us full url 
for example 
1 - localhost:8000/articles
2 - localhost:8000/articles?page=2
i think these two url must be different 