### PR TITLE
Allow passing $appendDefault on setTitle() from SEOTools

### DIFF
--- a/src/SEOTools/SEOTools.php
+++ b/src/SEOTools/SEOTools.php
@@ -35,12 +35,13 @@ class SEOTools implements SEOContract
      * Setup title for all seo providers.
      *
      * @param string $title
+     * @param bool   $appendDefault
      *
      * @return \Artesaos\SEOTools\Contracts\SEOTools
      */
-    public function setTitle($title)
+    public function setTitle($title, $appendDefault = true)
     {
-        $this->metatags()->setTitle($title);
+        $this->metatags()->setTitle($title, $appendDefault);
         $this->opengraph()->setTitle($title);
         $this->twitter()->setTitle($title);
 


### PR DESCRIPTION
If the general facade `SEO` is used, param $appendDefault is not accepted and then dev might need to use two different facades.

This is an non-breaking change as the $appendDefault has the default value (`true`).