### PR TITLE
Add basic support for setting meta robots

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ SEOMeta::setTitle($title);
 SEOMeta::setTitleDefault($default);
 SEOMeta::setDescription($description);
 SEOMeta::setKeywords($keywords);
+SEOMeta::setRobots($robots);
 SEOMeta::setTitleSeparator($separator);
 SEOMeta::setCanonical($url);
 SEOMeta::setPrev($url);
@@ -458,6 +459,7 @@ SEOMeta::getDescription();
 SEOMeta::getCanonical($url);
 SEOMeta::getPrev($url);
 SEOMeta::getNext($url);
+SEOMeta::getRobots();
 SEOMeta::reset();
 
 SEOMeta::generate();

--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -92,6 +92,13 @@ class SEOMeta implements MetaTagsContract
     protected $alternateLanguages = [];
 
     /**
+     * The meta robots.
+     *
+     * @var string
+     */
+    protected $robots;
+
+    /**
      * @var Config
      */
     protected $config;
@@ -137,6 +144,7 @@ class SEOMeta implements MetaTagsContract
         $prev = $this->getPrev();
         $next = $this->getNext();
         $languages = $this->getAlternateLanguages();
+        $robots = $this->getRobots();
 
         $html = [];
 
@@ -183,6 +191,10 @@ class SEOMeta implements MetaTagsContract
 
         foreach ($languages as $lang) {
             $html[] = "<link rel=\"alternate\" hreflang=\"{$lang['lang']}\" href=\"{$lang['url']}\"/>";
+        }
+
+        if ($robots) {
+            $html[] = "<meta name=\"robots\" content=\"{$robots}\">";
         }
 
         return ($minify) ? implode('', $html) : implode(PHP_EOL, $html);
@@ -420,6 +432,20 @@ class SEOMeta implements MetaTagsContract
     }
 
     /**
+     * Sets the meta robots.
+     *
+     * @param string $robots
+     *
+     * @return MetaTagsContract
+     */
+    public function setRobots($robots)
+    {
+        $this->robots = $robots;
+
+        return $this;
+    }
+
+    /**
      * Takes the title formatted for display.
      *
      * @return string
@@ -550,6 +576,16 @@ class SEOMeta implements MetaTagsContract
     }
 
     /**
+     * Get meta robots.
+     *
+     * @return string
+     */
+    public function getRobots()
+    {
+        return $this->robots ?: $this->config->get('defaults.robots', null);
+    }
+
+    /**
      * Reset all data.
      *
      * @return void
@@ -565,6 +601,7 @@ class SEOMeta implements MetaTagsContract
         $this->metatags = [];
         $this->keywords = [];
         $this->alternateLanguages = [];
+        $this->robots = null;
     }
 
     /**

--- a/src/resources/config/seotools.php
+++ b/src/resources/config/seotools.php
@@ -11,6 +11,7 @@ return [
             'separator'    => ' - ',
             'keywords'     => [],
             'canonical'    => false, // Set null for using Url::current(), set false to total remove
+            'robots'       => false, // Set to 'all', 'none' or any combination of index/noindex and follow/nofollow
         ],
 
         /*

--- a/tests/SEOTools/SEOMetaTest.php
+++ b/tests/SEOTools/SEOMetaTest.php
@@ -239,6 +239,7 @@ class SEOMetaTest extends BaseTest
         $this->seoMeta->setCanonical('test');
         $this->seoMeta->addMeta('test');
         $this->seoMeta->addAlternateLanguage('test', 'test');
+        $this->seoMeta->setRobots('all');
         $this->seoMeta->reset();
 
         $this->setRightAssertion($expected);
@@ -254,4 +255,23 @@ class SEOMetaTest extends BaseTest
 
         $this->assertEquals($expectedDom->C14N(), $actualDom->C14N());
     }
+
+    public function test_it_sets_default_meta_robots_to_none()
+    {
+        $this->assertEquals(null, $this->seoMeta->getRobots());
+    }
+
+    public function test_it_allows_setting_meta_robots()
+    {
+        $this->seoMeta->setRobots('all');
+        $this->assertEquals('all', $this->seoMeta->getRobots());
+
+        $expected = "<title>It's Over 9000!</title>";
+        $expected .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
+        $expected .= "<meta name=\"robots\" content=\"all\">";
+
+        $this->setRightAssertion($expected);
+    }
+
+
 }


### PR DESCRIPTION
This allows basic setting of meta robots (accepts any string) globally configurable via config file.

Requested in #106 and #67