### PR TITLE
Removed duplicated line in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,6 @@ SEOMeta::setTitleDefault($default);
 SEOMeta::setDescription($description);
 SEOMeta::setKeywords($keywords);
 SEOMeta::setRobots($robots);
-SEOMeta::setTitleSeparator($separator);
 SEOMeta::setCanonical($url);
 SEOMeta::setPrev($url);
 SEOMeta::setNext($url);


### PR DESCRIPTION
README.md file contains duplicated line in SEOMeta API section
`SEOMeta::setTitleSeparator($separator);`