### PR TITLE
Fix #122: UTF-8 encoding for the meta tags

### DIFF
--- a/src/SEOTools/OpenGraph.php
+++ b/src/SEOTools/OpenGraph.php
@@ -831,7 +831,7 @@ class OpenGraph implements OpenGraphContract
      */
     public function setDescription($description = null)
     {
-        return $this->addProperty('description', htmlentities($description));
+        return $this->addProperty('description', htmlspecialchars($description, ENT_QUOTES, 'UTF-8', false));
     }
 
     /**

--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -126,7 +126,7 @@ class SEOMeta implements MetaTagsContract
 
     /**
      * Generates meta tags.
-     * 
+     *
      * @param bool $minify
      *
      * @return string
@@ -263,7 +263,7 @@ class SEOMeta implements MetaTagsContract
     {
         // clean and store description
         // if is false, set false
-        $this->description = (false == $description) ? $description : strip_tags(htmlentities($description));
+        $this->description = (false == $description) ? $description : htmlspecialchars($description, ENT_QUOTES, 'UTF-8', false);
 
         return $this;
     }

--- a/src/SEOTools/TwitterCards.php
+++ b/src/SEOTools/TwitterCards.php
@@ -133,7 +133,7 @@ class TwitterCards implements TwitterCardsContract
      */
     public function setDescription($description)
     {
-        return $this->addValue('description', htmlentities($description));
+        return $this->addValue('description', htmlspecialchars($description, ENT_QUOTES, 'UTF-8', false));
     }
 
     /**
@@ -155,9 +155,9 @@ class TwitterCards implements TwitterCardsContract
      */
     public function addImage($image)
     {
-        foreach ((array)$image as $url):
+        foreach ((array) $image as $url) {
             $this->images[] = $url;
-        endforeach;
+        }
 
         return $this;
     }

--- a/tests/SEOTools/SEOMetaTest.php
+++ b/tests/SEOTools/SEOMetaTest.php
@@ -273,5 +273,20 @@ class SEOMetaTest extends BaseTest
         $this->setRightAssertion($expected);
     }
 
+    /**
+     * @depends test_set_description
+     *
+     * @see https://github.com/artesaos/seotools/issues/122
+     */
+    public function test_utf8()
+    {
+        $description = 'de fidélisation des salariés';
+        $fullHeader = "<title>It's Over 9000!</title>";
+        $fullHeader .= "<meta name=\"description\" content=\"".$description.'">';
 
+        $this->seoMeta->setDescription($description);
+
+        $this->assertEquals($description, $this->seoMeta->getDescription());
+        $this->setRightAssertion($fullHeader);
+    }
 }


### PR DESCRIPTION
Fix #122: UTF-8 encoding for the meta tags