### PR TITLE
Fix #165: `JsonLd` default URL generation

### DIFF
--- a/src/SEOTools/Contracts/JsonLd.php
+++ b/src/SEOTools/Contracts/JsonLd.php
@@ -55,7 +55,7 @@ interface JsonLd
     public function setDescription($description);
 
     /**
-     * @param string $url
+     * @param string|null|bool $url
      *
      * @return static
      */

--- a/src/SEOTools/JsonLd.php
+++ b/src/SEOTools/JsonLd.php
@@ -27,9 +27,9 @@ class JsonLd implements JsonLdContract
     protected $description = '';
 
     /**
-     * @var string
+     * @var string|null|bool
      */
-    protected $url = '';
+    protected $url = false;
 
     /**
      * @var array
@@ -72,18 +72,16 @@ class JsonLd implements JsonLdContract
             $generated['@type'] = $this->type;
         }
 
-
         if (!empty($this->title)) {
             $generated['name'] = $this->title;
         }
-
 
         if (!empty($this->description)) {
             $generated['description'] = $this->description;
         }
 
-        if (!empty($this->url)) {
-            $generated['url'] = $this->url;
+        if ($this->url !== false) {
+            $generated['url'] = $this->url ?? app('url')->full();
         }
 
         if (!empty($this->images)) {

--- a/tests/SEOTools/JsonLdTest.php
+++ b/tests/SEOTools/JsonLdTest.php
@@ -51,6 +51,18 @@ class JsonLdTest extends BaseTest
         $this->setRightAssertion($expected);
     }
 
+    /**
+     * @depends test_set_url
+     */
+    public function test_use_current_url()
+    {
+        $this->jsonLd->setUrl(null);
+
+        $expected = '<html><head><script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"For those who helped create the Genki Dama","url":"http:\/\/localhost"}</script></head></html>';
+
+        $this->setRightAssertion($expected);
+    }
+
     public function test_set_description()
     {
         $this->jsonLd->setDescription('Kamehamehaaaaaaaa');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #165