### PR TITLE
Fix #169: `JsonLd::__construct()` PHP error on empty arguments

### DIFF
--- a/src/SEOTools/JsonLd.php
+++ b/src/SEOTools/JsonLd.php
@@ -2,6 +2,7 @@
 
 namespace Artesaos\SEOTools;
 
+use Illuminate\Support\Arr;
 use Artesaos\SEOTools\Contracts\JsonLd as JsonLdContract;
 
 class JsonLd implements JsonLdContract
@@ -41,20 +42,15 @@ class JsonLd implements JsonLdContract
      */
     public function __construct(array $defaults = [])
     {
-        $this->setTitle($defaults['title']);
-        unset($defaults['title']);
+        $this->setTitle(Arr::pull($defaults, 'title', ''));
 
-        $this->setDescription($defaults['description']);
-        unset($defaults['description']);
+        $this->setDescription(Arr::pull($defaults, 'description', ''));
 
-        $this->setType($defaults['type']);
-        unset($defaults['type']);
+        $this->setType(Arr::pull($defaults, 'type', ''));
 
-        $this->setUrl($defaults['url']);
-        unset($defaults['url']);
+        $this->setUrl(Arr::pull($defaults, 'url', false));
 
-        $this->setImages($defaults['images']);
-        unset($defaults['images']);
+        $this->setImages(Arr::pull($defaults, 'images', []));
 
         $this->values = $defaults;
     }

--- a/tests/SEOTools/JsonLdTest.php
+++ b/tests/SEOTools/JsonLdTest.php
@@ -122,6 +122,16 @@ class JsonLdTest extends BaseTest
     }
 
     /**
+     * @see https://github.com/artesaos/seotools/issues/169
+     */
+    public function test_clear_construct()
+    {
+        $jsonLd = new JsonLd();
+
+        $this->assertTrue(is_object($jsonLd)); // no exception should occur so far
+    }
+
+    /**
      * @param $expectedString
      */
     protected function setRightAssertion($expectedString)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #169