### PR TITLE
Add class="notranslate" to meta tag

### DIFF
--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -146,7 +146,7 @@ class SEOMeta implements MetaTagsContract
         $html = [];
 
         if ($title) {
-            $html[] = "<title>$title</title>";
+            $html[] = Arr::get($this->config, 'add_notranslate_class', false) ? "<title class=\"notranslate\">$title</title>" : "<title>$title</title>";
         }
 
         if ($description) {

--- a/src/resources/config/seotools.php
+++ b/src/resources/config/seotools.php
@@ -27,6 +27,8 @@ return [
             'pinterest' => null,
             'yandex'    => null,
         ],
+
+        'add_notranslate_class' => false,
     ],
     'opengraph' => [
         /*

--- a/tests/SEOTools/SEOMetaTest.php
+++ b/tests/SEOTools/SEOMetaTest.php
@@ -289,4 +289,20 @@ class SEOMetaTest extends BaseTest
         $this->assertEquals($description, $this->seoMeta->getDescription());
         $this->setRightAssertion($fullHeader);
     }
+
+    public function test_it_can_add_notranslate_class_to_title()
+    {
+        $this->seoMeta = new SEOMeta(new \Illuminate\Config\Repository([
+            'add_notranslate_class' => true,
+            'defaults' => [
+                'title' => 'It\'s Over 9000!',
+                'description' => 'For those who helped create the Genki Dama',
+            ],
+        ]));
+        
+        $expected = "<title class=\"notranslate\">It's Over 9000!</title>";
+        $expected .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
+
+        $this->setRightAssertion($expected);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #139

This PR already uses config as an array instead of Illuminate/Config object, which will be removed from dependencies once the PR https://github.com/artesaos/seotools/pull/172 is merged.