### PR TITLE
Removed legacy phpunit flag

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          verbose="true"
 >
     <testsuites>


### PR DESCRIPTION
That configuration setting has not had an effect in years. It was removed long ago.