### PR TITLE
Fix open graph url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Artesaos\\SEOTools\\Test\\": "tests/"
+      "Artesaos\\SEOTools\\Tests\\": "tests/SEOTools"
     }
   },
   "config": {

--- a/src/SEOTools/OpenGraph.php
+++ b/src/SEOTools/OpenGraph.php
@@ -278,15 +278,16 @@ class OpenGraph implements OpenGraphContract
             [];
 
         foreach ($defaults as $key => $value) {
-            if ($key == 'images') {
+            if ($key === 'images') {
                 if (empty($this->images)) {
                     $this->images = $value;
                 }
-            } elseif ($key == 'url' && $value === null) {
-                $this->addProperty('url', $this->url ?: (($value === null)
-                    ? app('url')->current()
-                    : $this->config['defaults.url'])
-                );
+            } elseif ($key === 'url' && empty($value)) {
+                if ($value === null) {
+                    $this->addProperty('url', $this->url ?: app('url')->current());
+                } elseif ($this->url) {
+                    $this->addProperty('url', $this->url);
+                }
             } elseif (! empty($value) && ! array_key_exists($key, $this->properties)) {
                 $this->addProperty($key, $value);
             }

--- a/tests/SEOTools/JsonLdTest.php
+++ b/tests/SEOTools/JsonLdTest.php
@@ -154,7 +154,7 @@ class JsonLdTest extends BaseTest
     protected function setRightAssertion($expectedString)
     {
         $expectedDom = $this->makeDomDocument($expectedString);
-        $actualDom = $this->makeDomDocument($this->jsonLd->generate());
+        $actualDom = $this->makeDomDocument($this->jsonLd->generate(true));
 
         $this->assertEquals($expectedDom->C14N(), $actualDom->C14N());
     }

--- a/tests/SEOTools/SEOMetaTest.php
+++ b/tests/SEOTools/SEOMetaTest.php
@@ -251,7 +251,7 @@ class SEOMetaTest extends BaseTest
     protected function setRightAssertion($expectedString)
     {
         $expectedDom = $this->makeDomDocument($expectedString);
-        $actualDom = $this->makeDomDocument($this->seoMeta->generate());
+        $actualDom = $this->makeDomDocument($this->seoMeta->generate(true));
 
         $this->assertEquals($expectedDom->C14N(), $actualDom->C14N());
     }
@@ -299,7 +299,7 @@ class SEOMetaTest extends BaseTest
                 'description' => 'For those who helped create the Genki Dama',
             ],
         ]));
-        
+
         $expected = "<title class=\"notranslate\">It's Over 9000!</title>";
         $expected .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
 

--- a/tests/SEOTools/SEOToolsTest.php
+++ b/tests/SEOTools/SEOToolsTest.php
@@ -121,7 +121,7 @@ class SEOToolsTest extends BaseTest
     protected function setRightAssertion($expectedString)
     {
         $expectedDom = $this->makeDomDocument($expectedString);
-        $actualDom = $this->makeDomDocument($this->seoTools->generate());
+        $actualDom = $this->makeDomDocument($this->seoTools->generate(true));
 
         $this->assertEquals($expectedDom->C14N(), $actualDom->C14N());
     }

--- a/tests/SEOTools/TwitterCardsTest.php
+++ b/tests/SEOTools/TwitterCardsTest.php
@@ -105,7 +105,7 @@ class TwitterCardsTest extends BaseTest
     protected function setRightAssertion($expectedString)
     {
         $expectedDom = $this->makeDomDocument($expectedString);
-        $actualDom = $this->makeDomDocument($this->twitterCards->generate());
+        $actualDom = $this->makeDomDocument($this->twitterCards->generate(true));
 
         $this->assertEquals($expectedDom->C14N(), $actualDom->C14N());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #183 

**Fixed breaking change:**
Brings back ability to override Open Graph Url, if default url set to `false`

This PR also fix:
- autoloading tests path in `composer.json`
- `setRightAssertion` method now minifing generated result, because all expected results set without line breaks