### PR TITLE
Fix #183: Ability to override Open Graph Url, if default url set to `false`

### DIFF
--- a/src/SEOTools/OpenGraph.php
+++ b/src/SEOTools/OpenGraph.php
@@ -278,15 +278,16 @@ class OpenGraph implements OpenGraphContract
             [];
 
         foreach ($defaults as $key => $value) {
-            if ($key == 'images') {
+            if ($key === 'images') {
                 if (empty($this->images)) {
                     $this->images = $value;
                 }
-            } elseif ($key == 'url' && $value === null) {
-                $this->addProperty('url', $this->url ?: (($value === null)
-                    ? app('url')->current()
-                    : $this->config['defaults.url'])
-                );
+            } elseif ($key === 'url' && empty($value)) {
+                if ($value === null) {
+                    $this->addProperty('url', $this->url ?: app('url')->current());
+                } elseif ($this->url) {
+                    $this->addProperty('url', $this->url);
+                }
             } elseif (! empty($value) && ! array_key_exists($key, $this->properties)) {
                 $this->addProperty($key, $value);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️

### What steps will reproduce the problem?

By default, OpenGraph url set to `false` in config file. When I set a custom url by `OpenGraph::setUrl('https://some.url')` it doesn't reflect, open graph url will not render due to this PR - https://github.com/artesaos/seotools/pull/148
It works only if you set default config value to `null` instead of `false`.

### What is the expected result?

Ability to set custom open graph url regardless of default url value

### What do you get instead?

Ability to set custom open graph url only if change a default config value to null

### Additional info

| Q                         | A
| ------------------------- | ---
| This Package Version      | 0.15.0+
| Laravel Framework Version | 5.8+
| PHP version               |  7.3
| Operating system          | MacOS

I think condition on [this row](https://github.com/artesaos/seotools/blob/master/src/SEOTools/OpenGraph.php#L285) should be:

```php
 elseif ($key == 'url' && !$value)
```

or

```php
 elseif ($key == 'url' && empty($value))
```