### PR TITLE
Fix cyrillic symbols

### DIFF
--- a/src/SEOTools/JsonLd.php
+++ b/src/SEOTools/JsonLd.php
@@ -95,7 +95,7 @@ class JsonLd implements JsonLdContract
 
         $generated = array_merge($generated, $this->values);
 
-        return '<script type="application/ld+json">' . json_encode($generated) . '</script>';
+        return '<script type="application/ld+json">' . json_encode($generated, JSON_UNESCAPED_UNICODE) . '</script>';
     }
 
     /**


### PR DESCRIPTION
When using cyrillic symbols they are automatically escaped but for better readability is prefered to not escape them

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any