### PR TITLE
Add `Norton safeweb` to webmaster tags list

### DIFF
--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -120,6 +120,7 @@ class SEOMeta implements MetaTagsContract
         'alexa'    => 'alexaVerifyID',
         'pintrest' => 'p:domain_verify',
         'yandex'   => 'yandex-verification',
+        'norton'   => 'norton-safeweb-site-verification',
     ];
 
     /**

--- a/src/resources/config/seotools.php
+++ b/src/resources/config/seotools.php
@@ -26,6 +26,7 @@ return [
             'alexa'     => null,
             'pinterest' => null,
             'yandex'    => null,
+            'norton'    => null,
         ],
 
         'add_notranslate_class' => false,


### PR DESCRIPTION
Hi,

With this PR I would like to propose you to add the **Norton Safe Web** tag to the webmaster tags list.

Source: [Norton Safeweb](https://safeweb.norton.com/help/site_owners)