### PR TITLE
Remove usage of helper function array_forget

### DIFF
--- a/src/SEOTools/OpenGraph.php
+++ b/src/SEOTools/OpenGraph.php
@@ -2,6 +2,7 @@
 
 namespace Artesaos\SEOTools;
 
+use Illuminate\Support\Arr;
 use Artesaos\SEOTools\Contracts\OpenGraph as OpenGraphContract;
 
 /**
@@ -697,7 +698,7 @@ class OpenGraph implements OpenGraphContract
      */
     public function removeProperty($key)
     {
-        array_forget($this->properties, $key);
+        Arr::forget($this->properties, $key);
 
         return $this;
     }


### PR DESCRIPTION
Helper functions removed from illuminate/support since version 7.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️/❌ - currently there are 23 failures in phpunit test, which should be fixed by PR #192
| Fixed issues  | #188