### PR TITLE
add/image alternative Text to Open Graph Data

### DIFF
--- a/src/SEOTools/OpenGraph.php
+++ b/src/SEOTools/OpenGraph.php
@@ -716,6 +716,7 @@ class OpenGraph implements OpenGraphContract
             'type',
             'width',
             'height',
+            'alt',
         ];
 
         if (is_array($source)) {


### PR DESCRIPTION
- add the meta property "og:image:alt" to the Open Graph Class
- will generate something like this: `<meta property="og:image:alt" content="alternative image Text">`

The property is described here: https://ogp.me/#structured

> og:image:alt - A description of what is in the image (not a caption). If the page specifies an og:image it should specify og:image:alt.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -