### PR TITLE
Fix jsonld image array generate

### DIFF
--- a/src/SEOTools/JsonLd.php
+++ b/src/SEOTools/JsonLd.php
@@ -108,7 +108,7 @@ class JsonLd implements JsonLdContract
         }
 
         if (! empty($this->images)) {
-            $generated['image'] = count($this->images) === 1 ? reset($this->images) : json_encode($this->images);
+            $generated['image'] = count($this->images) === 1 ? reset($this->images) : $this->images;
         }
 
         $generated = array_merge($generated, $this->values);

--- a/tests/SEOTools/JsonLdMultiTest.php
+++ b/tests/SEOTools/JsonLdMultiTest.php
@@ -110,7 +110,7 @@ class JsonLdMultiTest extends BaseTest
         $this->jsonLdMulti->setImages(['sayajin.png', 'namekusei.png']);
 
         $expected = '<html><head>' . $this->defaultJsonLdHtml
-            . '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"For those who helped create the Genki Dama","image":"[\"sayajin.png\",\"namekusei.png\"]"}</script></head></html>';
+            . '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"For those who helped create the Genki Dama","image":["sayajin.png","namekusei.png"]}</script></head></html>';
 
         $this->setRightAssertion($expected);
     }

--- a/tests/SEOTools/JsonLdTest.php
+++ b/tests/SEOTools/JsonLdTest.php
@@ -97,7 +97,7 @@ class JsonLdTest extends BaseTest
     {
         $this->jsonLd->setImages(['sayajin.png', 'namekusei.png']);
 
-        $expected = '<html><head><script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"For those who helped create the Genki Dama","image":"[\"sayajin.png\",\"namekusei.png\"]"}</script></head></html>';
+        $expected = '<html><head><script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"For those who helped create the Genki Dama","image":["sayajin.png","namekusei.png"]}</script></head></html>';
 
         $this->setRightAssertion($expected);
     }

--- a/tests/SEOTools/SEOMetaTest.php
+++ b/tests/SEOTools/SEOMetaTest.php
@@ -116,7 +116,7 @@ class SEOMetaTest extends BaseTest
         $this->seoMeta->setKeywords($keywords);
 
         $this->setRightAssertion($fullHeader);
-        $this->assertEquals($keywords, implode($this->seoMeta->getKeywords(), ','));
+        $this->assertEquals($keywords, implode(',', $this->seoMeta->getKeywords()));
     }
 
     public function test_add_keywords()
@@ -129,11 +129,11 @@ class SEOMetaTest extends BaseTest
         $this->seoMeta->addKeyword('makankosappo');
 
         $this->setRightAssertion($fullHeader);
-        $this->assertEquals('masenko, makankosappo', implode($this->seoMeta->getKeywords(), ', '));
+        $this->assertEquals('masenko, makankosappo', implode(', ', $this->seoMeta->getKeywords()));
 
         $this->seoMeta->addKeyword(['kienzan', 'tayoken']);
 
-        $this->assertEquals('kienzan, tayoken, masenko, makankosappo', implode($this->seoMeta->getKeywords(), ', '));
+        $this->assertEquals('kienzan, tayoken, masenko, makankosappo', implode(', ', $this->seoMeta->getKeywords()));
     }
 
     public function test_remove_metatag()

--- a/tests/SEOTools/SEOToolsTest.php
+++ b/tests/SEOTools/SEOToolsTest.php
@@ -98,7 +98,7 @@ class SEOToolsTest extends BaseTest
         $expected .= '<meta property="og:image" content="Kamehamehaaaaaaa.png" />';
         $expected .= '<meta property="og:image" content="Kamehamehaaaaaaa.png" />';
         $expected .= '<meta name="twitter:image" content="Kamehamehaaaaaaa.png" />';
-        $expected .= '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"For those who helped create the Genki Dama","image":"[\"Kamehamehaaaaaaa.png\",\"Kamehamehaaaaaaa.png\"]"}</script>';
+        $expected .= '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"For those who helped create the Genki Dama","image":["Kamehamehaaaaaaa.png","Kamehamehaaaaaaa.png"]}</script>';
 
         $this->setRightAssertion($expected);
     }


### PR DESCRIPTION
When images on a JsonLD object is an array, it rendered corrupt JSON
because the array gets json_encode() twice. This commit fixes that.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #219