### PR TITLE
Support for PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0snapshot
   - hhvm
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": "^7.1 || ^8.0",
     "ext-json": "*",
     "illuminate/config": "5.8.* || ^6.0 || ^7.0 || ^8.0",
     "illuminate/support": "5.8.* || ^6.0 || ^7.0 || ^8.0"


### PR DESCRIPTION
Enabled PHP 8.0 builds on Travis and added PHP 8.0 to Composer requirements.