### PR TITLE
use PHP 8 on travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 
 php:
-  - 7.1
-  - 7.2
-  - 7.3
   - 7.4
+  - 8.0
   - hhvm
 
 matrix:


### PR DESCRIPTION
Allow travist to test with PHP8
Closes #232