### PR TITLE
fix: add ability to use Url::current() as default canonical via config

### DIFF
--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -470,9 +470,19 @@ class SEOMeta implements MetaTagsContract
      */
     public function getCanonical()
     {
+        if ($this->canonical) {
+            return $this->canonical;
+        }
+
         $canonical_config = $this->config->get('defaults.canonical', false);
 
-        return $this->canonical ?: (($canonical_config === null) ? htmlspecialchars(app('url')->full()) : $canonical_config);
+        if ($canonical_config === null || $canonical_config === 'full') {
+            return htmlspecialchars(app('url')->full());
+        } elseif ($canonical_config === 'current') {
+            return htmlspecialchars(app('url')->current());
+        }
+
+        return $canonical_config;
     }
 
     /**

--- a/src/resources/config/seotools.php
+++ b/src/resources/config/seotools.php
@@ -14,7 +14,7 @@ return [
             'description'  => 'For those who helped create the Genki Dama', // set false to total remove
             'separator'    => ' - ',
             'keywords'     => [],
-            'canonical'    => false, // Set null for using Url::current(), set false to total remove
+            'canonical'    => false, // Set to null or 'full' to use Url::full(), set to 'current' to use Url::current(), set false to total remove
             'robots'       => false, // Set to 'all', 'none' or any combination of index/noindex and follow/nofollow
         ],
         /*

--- a/tests/SEOTools/SEOMetaTest.php
+++ b/tests/SEOTools/SEOMetaTest.php
@@ -168,6 +168,50 @@ class SEOMetaTest extends BaseTest
         $this->assertEquals($canonical, $this->seoMeta->getCanonical());
     }
 
+    public function dataTestUrls()
+    {
+        return [
+            ['http://localhost/hello/world', 'http://localhost/hello/world'],
+            ['http://localhost/hello/world?param=1', 'http://localhost/hello/world'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataTestUrls
+     */
+    public function test_get_canonical_null($fullUrl)
+    {
+        config()->set('defaults.canonical', null);
+        $this->seoMeta = new SEOMeta(config());
+
+        $this->get($fullUrl);
+        $this->assertEquals($fullUrl, $this->seoMeta->getCanonical());
+    }
+
+    /**
+     * @dataProvider dataTestUrls
+     */
+    public function test_get_canonical_full($fullUrl)
+    {
+        config()->set('defaults.canonical', 'full');
+        $this->seoMeta = new SEOMeta(config());
+
+        $this->get($fullUrl);
+        $this->assertEquals($fullUrl, $this->seoMeta->getCanonical());
+    }
+
+    /**
+     * @dataProvider dataTestUrls
+     */
+    public function test_get_canonical_current($fullUrl, $currentUrl)
+    {
+        config()->set('defaults.canonical', 'current');
+        $this->seoMeta = new SEOMeta(config());
+
+        $this->get($fullUrl);
+        $this->assertEquals($currentUrl, $this->seoMeta->getCanonical());
+    }
+
     public function test_set_amp()
     {
         $fullHeader = "<title>It's Over 9000!</title>";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #180, #190 

While I personally feel Url::full() should never be used for a canonical URL, this gives a path to use a correct default URL in the package versus needing to set it manually.