### PR TITLE
Fix JsonLd default url

### DIFF
--- a/src/SEOTools/JsonLd.php
+++ b/src/SEOTools/JsonLd.php
@@ -117,7 +117,13 @@ class JsonLd implements JsonLdContract
         }
 
         if ($this->url !== false) {
-            $generated['url'] = $this->url ?? app('url')->full();
+            if ($this->url === null || $this->url === 'full') {
+                $generated['url'] = app('url')->full();
+            } elseif ($this->url === 'current') {
+                $generated['url'] = app('url')->current();
+            } else {
+                $generated['url'] = $this->url;
+            }
         }
 
         if (!empty($this->images)) {

--- a/src/resources/config/seotools.php
+++ b/src/resources/config/seotools.php
@@ -60,7 +60,7 @@ return [
         'defaults' => [
             'title'       => 'Over 9000 Thousand!', // set false to total remove
             'description' => 'For those who helped create the Genki Dama', // set false to total remove
-            'url'         => false, // Set null for using Url::current(), set false to total remove
+            'url'         => false, // Set to null or 'full' to use Url::full(), set to 'current' to use Url::current(), set false to total remove
             'type'        => 'WebPage',
             'images'      => [],
         ],


### PR DESCRIPTION
The docs state that when providing `null` as the default JsonLd URL `URL::current()` is used. But actually `URL::full()` was used.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -