### PR TITLE
Removed url from sanitized values

### DIFF
--- a/src/SEOTools/OpenGraph.php
+++ b/src/SEOTools/OpenGraph.php
@@ -263,7 +263,7 @@ class OpenGraph implements OpenGraphContract
      */
     protected function makeTag($key = null, $value = null, $ogPrefix = false)
     {
-        $value = str_replace(['http-equiv=', 'url='], '', $value);
+        $value = str_replace(['http-equiv='], '', $value);
         return sprintf(
             '<meta property="%s%s" content="%s" />%s',
             $ogPrefix ? $this->og_prefix : '',

--- a/src/SEOTools/TwitterCards.php
+++ b/src/SEOTools/TwitterCards.php
@@ -83,7 +83,7 @@ class TwitterCards implements TwitterCardsContract
      */
     private function makeTag($key, $value)
     {
-        $value = str_replace(['http-equiv=', 'url='], '', $value);
+        $value = str_replace(['http-equiv='], '', $value);
         return '<meta name="'.$this->prefix.strip_tags($key).'" content="'.strip_tags($value).'" />';
     }
 


### PR DESCRIPTION
This PR proposes removing `url=` from the list of sanitized values when generating a tag for Twitter and OG.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #257 