### PR TITLE
JsonLdMulti - Remove requirement for 2 items

### DIFF
--- a/src/SEOTools/JsonLdMulti.php
+++ b/src/SEOTools/JsonLdMulti.php
@@ -47,11 +47,9 @@ class JsonLdMulti implements JsonLdMultiContract
      */
     public function generate($minify = false)
     {
-        if (count($this->list) > 1) {
-            return array_reduce($this->list, function (string $output, JsonLd $jsonLd) {
-                return $output . (! $jsonLd->isEmpty() ? $jsonLd->generate() : '');
-            }, '');
-        }
+        return array_reduce($this->list, function (string $output, JsonLd $jsonLd) {
+            return $output . (! $jsonLd->isEmpty() ? $jsonLd->generate() : '');
+        }, '');
     }
 
     /**

--- a/tests/SEOTools/JsonLdMultiTest.php
+++ b/tests/SEOTools/JsonLdMultiTest.php
@@ -30,6 +30,15 @@ class JsonLdMultiTest extends BaseTest
         $this->jsonLdMulti->newJsonLd();
     }
 
+    public function test_single_instance()
+    {
+        $jsonLdSingle = new JsonLdMulti();
+
+        $expected = '<html><head>' . $this->defaultJsonLdHtml . '</head></html>';
+
+        $this->assertEquals($this->makeDomDocument($expected)->C14N(), $this->makeDomDocument($jsonLdSingle->generate())->C14N());
+    }
+
     public function test_set_title()
     {
         $this->jsonLdMulti->setTitle('Kamehamehaaaaaaaa');


### PR DESCRIPTION
`JsonLdMulti` does not output anything on default; this is inconsistent with the use of `JsonLd`.
The impact is high because this makes `JsonLdMulti` not be usable as default replacement for `JsonLd`.

This pull request removes the check for minimum 2 items.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #275