### PR TITLE
Prevent self-closing tag syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ class CommomController extends Controller
         OpenGraph::addImage($post->images->list('url'));
         OpenGraph::addImage(['url' => 'http://image.url.com/cover.jpg', 'size' => 300]);
         OpenGraph::addImage('http://image.url.com/cover.jpg', ['height' => 300, 'width' => 300]);
-        
+
         JsonLd::setTitle($post->title);
         JsonLd::setDescription($post->resume);
         JsonLd::setType('Article');
@@ -485,30 +485,30 @@ class CommomController extends Controller
 <html>
 <head>
     <title>Title - Over 9000 Thousand!</title>
-    <meta name='description' itemprop='description' content='description...' />
-    <meta name='keywords' content='key1, key2, key3' />
-    <meta property='article:published_time' content='2015-01-31T20:30:11-02:00' />
-    <meta property='article:section' content='news' />
+    <meta name='description' itemprop='description' content='description...'>
+    <meta name='keywords' content='key1, key2, key3'>
+    <meta property='article:published_time' content='2015-01-31T20:30:11-02:00'>
+    <meta property='article:section' content='news'>
 
-    <meta property="og:description"content="description..." />
-    <meta property="og:title"content="Title" />
-    <meta property="og:url"content="http://current.url.com" />
-    <meta property="og:type"content="article" />
-    <meta property="og:locale"content="pt-br" />
-    <meta property="og:locale:alternate"content="pt-pt" />
-    <meta property="og:locale:alternate"content="en-us" />
-    <meta property="og:site_name"content="name" />
-    <meta property="og:image"content="http://image.url.com/cover.jpg" />
-    <meta property="og:image"content="http://image.url.com/img1.jpg" />
-    <meta property="og:image"content="http://image.url.com/img2.jpg" />
-    <meta property="og:image"content="http://image.url.com/img3.jpg" />
-    <meta property="og:image:url"content="http://image.url.com/cover.jpg" />
-    <meta property="og:image:size"content="300" />
+    <meta property="og:description" content="description...">
+    <meta property="og:title" content="Title">
+    <meta property="og:url" content="http://current.url.com">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="pt-br">
+    <meta property="og:locale:alternate" content="pt-pt">
+    <meta property="og:locale:alternate" content="en-us">
+    <meta property="og:site_name" content="name">
+    <meta property="og:image" content="http://image.url.com/cover.jpg">
+    <meta property="og:image" content="http://image.url.com/img1.jpg">
+    <meta property="og:image" content="http://image.url.com/img2.jpg">
+    <meta property="og:image" content="http://image.url.com/img3.jpg">
+    <meta property="og:image:url" content="http://image.url.com/cover.jpg">
+    <meta property="og:image:size" content="300">
 
-    <meta name="twitter:card"content="summary" />
-    <meta name="twitter:title"content="Title" />
-    <meta name="twitter:site"content="@LuizVinicius73" />
-    
+    <meta name="twitter:card"content="summary">
+    <meta name="twitter:title"content="Title">
+    <meta name="twitter:site"content="@LuizVinicius73">
+
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","name":"Title - Over 9000 Thousand!"}</script>
     <!-- OR with multi -->
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","name":"Title - Over 9000 Thousand!"}</script>

--- a/src/SEOTools/OpenGraph.php
+++ b/src/SEOTools/OpenGraph.php
@@ -264,7 +264,7 @@ class OpenGraph implements OpenGraphContract
     protected function makeTag($key = null, $value = null, $ogPrefix = false)
     {
         return sprintf(
-            '<meta property="%s%s" content="%s" />%s',
+            '<meta property="%s%s" content="%s">%s',
             $ogPrefix ? $this->og_prefix : '',
             strip_tags($key),
             $this->cleanTagValue($value),

--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -160,11 +160,11 @@ class SEOMeta implements MetaTagsContract
         }
 
         if (!empty($keywords)) {
-            
+
             if($keywords instanceof \Illuminate\Support\Collection){
                 $keywords = $keywords->toArray();
             }
-            
+
             $keywords = implode(', ', $keywords);
             $html[] = "<meta name=\"keywords\" content=\"{$keywords}\">";
         }
@@ -182,23 +182,23 @@ class SEOMeta implements MetaTagsContract
         }
 
         if ($canonical) {
-            $html[] = "<link rel=\"canonical\" href=\"{$canonical}\"/>";
+            $html[] = "<link rel=\"canonical\" href=\"{$canonical}\">";
         }
 
         if ($amphtml) {
-            $html[] = "<link rel=\"amphtml\" href=\"{$amphtml}\"/>";
+            $html[] = "<link rel=\"amphtml\" href=\"{$amphtml}\">";
         }
 
         if ($prev) {
-            $html[] = "<link rel=\"prev\" href=\"{$prev}\"/>";
+            $html[] = "<link rel=\"prev\" href=\"{$prev}\">";
         }
 
         if ($next) {
-            $html[] = "<link rel=\"next\" href=\"{$next}\"/>";
+            $html[] = "<link rel=\"next\" href=\"{$next}\">";
         }
 
         foreach ($languages as $lang) {
-            $html[] = "<link rel=\"alternate\" hreflang=\"{$lang['lang']}\" href=\"{$lang['url']}\"/>";
+            $html[] = "<link rel=\"alternate\" hreflang=\"{$lang['lang']}\" href=\"{$lang['url']}\">";
         }
 
         if ($robots) {
@@ -215,7 +215,7 @@ class SEOMeta implements MetaTagsContract
     {
         // open redirect vulnerability fix
         $title = str_replace(['http-equiv=', 'url='], '', $title);
-        
+
         // clean title
         $title = strip_tags($title);
 

--- a/src/SEOTools/TwitterCards.php
+++ b/src/SEOTools/TwitterCards.php
@@ -84,7 +84,7 @@ class TwitterCards implements TwitterCardsContract
     private function makeTag($key, $value)
     {
         return sprintf(
-            '<meta name="%s" content="%s" />',
+            '<meta name="%s" content="%s">',
             $this->prefix.strip_tags($key),
             $this->cleanTagValue($value)
         );

--- a/tests/SEOTools/OpenGraphTest.php
+++ b/tests/SEOTools/OpenGraphTest.php
@@ -29,7 +29,7 @@ class OpenGraphTest extends BaseTest
         $this->openGraphs->setTitle('Hello, Ali');
         $this->openGraphs->setDescription('This is a test by Ali.');
 
-        $expected = '<meta property="og:title" content="Hello, Ali" /><meta property="og:description" content="This is a test by Ali." />';
+        $expected = '<meta property="og:title" content="Hello, Ali"><meta property="og:description" content="This is a test by Ali.">';
 
         $this->setRightAssertion($expected);
 
@@ -39,7 +39,7 @@ class OpenGraphTest extends BaseTest
     {
         $this->openGraphs->setUrl('https://www.domain.com');
 
-        $expected = '<meta property="og:title" content="Over 9000 Thousand!" /><meta property="og:description" content="For those who helped create the Genki Dama" /><meta content="https://www.domain.com" property="og:url">';
+        $expected = '<meta property="og:title" content="Over 9000 Thousand!"><meta property="og:description" content="For those who helped create the Genki Dama"><meta content="https://www.domain.com" property="og:url">';
 
         $this->setRightAssertion($expected);
 
@@ -54,7 +54,7 @@ class OpenGraphTest extends BaseTest
             "tag" => $tags,
         ]);
 
-        $expected = '<meta content="article" property="og:type"><meta property="og:title" content="Over 9000 Thousand!" /><meta property="og:description" content="For those who helped create the Genki Dama" /><meta property="article:tag" content="Example" /><meta property="article:tag" content="tags" /><meta property="article:tag" content="test" />';
+        $expected = '<meta content="article" property="og:type"><meta property="og:title" content="Over 9000 Thousand!"><meta property="og:description" content="For those who helped create the Genki Dama"><meta property="article:tag" content="Example"><meta property="article:tag" content="tags"><meta property="article:tag" content="test">';
 
         $this->setRightAssertion($expected);
     }

--- a/tests/SEOTools/SEOMetaTest.php
+++ b/tests/SEOTools/SEOMetaTest.php
@@ -159,7 +159,7 @@ class SEOMetaTest extends BaseTest
     {
         $fullHeader = "<title>It's Over 9000!</title>";
         $fullHeader .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
-        $fullHeader .= "<link rel=\"canonical\" href=\"http://domain.com\"/>";
+        $fullHeader .= "<link rel=\"canonical\" href=\"http://domain.com\">";
         $canonical = 'http://domain.com';
 
         $this->seoMeta->setCanonical($canonical);
@@ -216,7 +216,7 @@ class SEOMetaTest extends BaseTest
     {
         $fullHeader = "<title>It's Over 9000!</title>";
         $fullHeader .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
-        $fullHeader .= "<link rel=\"amphtml\" href=\"http://domain.com/amp\"/>";
+        $fullHeader .= "<link rel=\"amphtml\" href=\"http://domain.com/amp\">";
         $amphtml = 'http://domain.com/amp';
 
         $this->seoMeta->setAmpHtml($amphtml);
@@ -229,7 +229,7 @@ class SEOMetaTest extends BaseTest
     {
         $fullHeader = "<title>It's Over 9000!</title>";
         $fullHeader .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
-        $fullHeader .= "<link rel=\"next\" href=\"http://domain.com\"/>";
+        $fullHeader .= "<link rel=\"next\" href=\"http://domain.com\">";
         $next = 'http://domain.com';
 
         $this->seoMeta->setNext($next);
@@ -242,7 +242,7 @@ class SEOMetaTest extends BaseTest
     {
         $fullHeader = "<title>It's Over 9000!</title>";
         $fullHeader .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
-        $fullHeader .= "<link rel=\"prev\" href=\"http://domain.com\"/>";
+        $fullHeader .= "<link rel=\"prev\" href=\"http://domain.com\">";
         $prev = 'http://domain.com';
 
         $this->seoMeta->setPrev($prev);
@@ -255,7 +255,7 @@ class SEOMetaTest extends BaseTest
     {
         $fullHeader = "<title>It's Over 9000!</title>";
         $fullHeader .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
-        $fullHeader .= "<link rel=\"alternate\" hreflang=\"en\" href=\"http://domain.com\"/>";
+        $fullHeader .= "<link rel=\"alternate\" hreflang=\"en\" href=\"http://domain.com\">";
         $lang = 'en';
         $langUrl = 'http://domain.com';
 

--- a/tests/SEOTools/SEOToolsTest.php
+++ b/tests/SEOTools/SEOToolsTest.php
@@ -48,9 +48,9 @@ class SEOToolsTest extends BaseTest
 
         $expected = "<title>Kamehamehaaaaaaa - It's Over 9000!</title>";
         $expected .= '<meta name="description" content="For those who helped create the Genki Dama">';
-        $expected .= '<meta property="og:title" content="Kamehamehaaaaaaa" />';
-        $expected .= '<meta property="og:description" content="For those who helped create the Genki Dama" />';
-        $expected .= '<meta name="twitter:title" content="Kamehamehaaaaaaa" />';
+        $expected .= '<meta property="og:title" content="Kamehamehaaaaaaa">';
+        $expected .= '<meta property="og:description" content="For those who helped create the Genki Dama">';
+        $expected .= '<meta name="twitter:title" content="Kamehamehaaaaaaa">';
         $expected .= '<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Kamehamehaaaaaaa","description":"For those who helped create the Genki Dama"}</script>';
 
         $this->assertEquals('Kamehamehaaaaaaa - It\'s Over 9000!', $this->seoTools->getTitle());
@@ -63,9 +63,9 @@ class SEOToolsTest extends BaseTest
 
         $expected = "<title>It's Over 9000!</title>";
         $expected .= '<meta name="description" content="Kamehamehaaaaaaa">';
-        $expected .= '<meta property="og:description" content="Kamehamehaaaaaaa" />';
-        $expected .= '<meta property="og:title" content="Over 9000 Thousand!" />';
-        $expected .= '<meta name="twitter:description" content="Kamehamehaaaaaaa" />';
+        $expected .= '<meta property="og:description" content="Kamehamehaaaaaaa">';
+        $expected .= '<meta property="og:title" content="Over 9000 Thousand!">';
+        $expected .= '<meta name="twitter:description" content="Kamehamehaaaaaaa">';
         $expected .= '<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"Kamehamehaaaaaaa"}</script>';
 
 
@@ -78,9 +78,9 @@ class SEOToolsTest extends BaseTest
 
         $expected = "<title>It's Over 9000!</title>";
         $expected .= '<meta name="description" content="For those who helped create the Genki Dama">';
-        $expected .= '<link rel="canonical" href="http://domain.com"/>';
-        $expected .= '<meta property="og:title" content="Over 9000 Thousand!" />';
-        $expected .= '<meta property="og:description" content="For those who helped create the Genki Dama" />';
+        $expected .= '<link rel="canonical" href="http://domain.com">';
+        $expected .= '<meta property="og:title" content="Over 9000 Thousand!">';
+        $expected .= '<meta property="og:description" content="For those who helped create the Genki Dama">';
         $expected .= '<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"For those who helped create the Genki Dama"}</script>';
 
         $this->setRightAssertion($expected);
@@ -93,11 +93,11 @@ class SEOToolsTest extends BaseTest
 
         $expected = "<title>It's Over 9000!</title>";
         $expected .= '<meta name="description" content="For those who helped create the Genki Dama">';
-        $expected .= '<meta property="og:title" content="Over 9000 Thousand!" />';
-        $expected .= '<meta property="og:description" content="For those who helped create the Genki Dama" />';
-        $expected .= '<meta property="og:image" content="Kamehamehaaaaaaa.png" />';
-        $expected .= '<meta property="og:image" content="Kamehamehaaaaaaa.png" />';
-        $expected .= '<meta name="twitter:image" content="Kamehamehaaaaaaa.png" />';
+        $expected .= '<meta property="og:title" content="Over 9000 Thousand!">';
+        $expected .= '<meta property="og:description" content="For those who helped create the Genki Dama">';
+        $expected .= '<meta property="og:image" content="Kamehamehaaaaaaa.png">';
+        $expected .= '<meta property="og:image" content="Kamehamehaaaaaaa.png">';
+        $expected .= '<meta name="twitter:image" content="Kamehamehaaaaaaa.png">';
         $expected .= '<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"For those who helped create the Genki Dama","image":["Kamehamehaaaaaaa.png","Kamehamehaaaaaaa.png"]}</script>';
 
         $this->setRightAssertion($expected);
@@ -107,8 +107,8 @@ class SEOToolsTest extends BaseTest
     {
         $expected = "<title>It's Over 9000!</title>";
         $expected .= '<meta name="description" content="For those who helped create the Genki Dama">';
-        $expected .= '<meta property="og:title" content="Over 9000 Thousand!" />';
-        $expected .= '<meta property="og:description" content="For those who helped create the Genki Dama" />';
+        $expected .= '<meta property="og:title" content="Over 9000 Thousand!">';
+        $expected .= '<meta property="og:description" content="For those who helped create the Genki Dama">';
         $expected .= '<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"For those who helped create the Genki Dama"}</script>';
 
         $this->setRightAssertion($expected);

--- a/tests/SEOTools/TwitterCardsTest.php
+++ b/tests/SEOTools/TwitterCardsTest.php
@@ -28,7 +28,7 @@ class TwitterCardsTest extends BaseTest
     {
         $this->twitterCards->setTitle('Kamehamehaaaaaaaa');
 
-        $expected = '<meta name="twitter:title" content="Kamehamehaaaaaaaa" />';
+        $expected = '<meta name="twitter:title" content="Kamehamehaaaaaaaa">';
 
         $this->setRightAssertion($expected);
     }
@@ -37,7 +37,7 @@ class TwitterCardsTest extends BaseTest
     {
         $this->twitterCards->setSite('http://kakaroto.9000');
 
-        $expected = '<meta name="twitter:site" content="http://kakaroto.9000" />';
+        $expected = '<meta name="twitter:site" content="http://kakaroto.9000">';
 
         $this->setRightAssertion($expected);
     }
@@ -46,7 +46,7 @@ class TwitterCardsTest extends BaseTest
     {
         $this->twitterCards->setUrl('http://kakaroto.9000');
 
-        $expected = '<meta name="twitter:url" content="http://kakaroto.9000" />';
+        $expected = '<meta name="twitter:url" content="http://kakaroto.9000">';
 
         $this->setRightAssertion($expected);
     }
@@ -55,7 +55,7 @@ class TwitterCardsTest extends BaseTest
     {
         $this->twitterCards->setDescription('Kamehamehaaaaaaaa');
 
-        $expected = '<meta name="twitter:description" content="Kamehamehaaaaaaaa" />';
+        $expected = '<meta name="twitter:description" content="Kamehamehaaaaaaaa">';
 
         $this->setRightAssertion($expected);
     }
@@ -66,7 +66,7 @@ class TwitterCardsTest extends BaseTest
 
         $this->twitterCards->setDescription($description);
 
-        $expected = '<meta name="twitter:description" content="&quot;Foo bar&quot; -&gt; abc" />';
+        $expected = '<meta name="twitter:description" content="&quot;Foo bar&quot; -&gt; abc">';
 
         $this->setRightAssertion($expected);
     }
@@ -75,7 +75,7 @@ class TwitterCardsTest extends BaseTest
     {
         $this->twitterCards->setType('sayajin');
 
-        $expected = '<meta name="twitter:card" content="sayajin" />';
+        $expected = '<meta name="twitter:card" content="sayajin">';
 
         $this->setRightAssertion($expected);
     }
@@ -84,8 +84,8 @@ class TwitterCardsTest extends BaseTest
     {
         $this->twitterCards->setImages(['sayajin.png', 'namekusei.png']);
 
-        $expected = "<meta name=\"twitter:images0\" content=\"sayajin.png\" />";
-        $expected .= "<meta name=\"twitter:images1\" content=\"namekusei.png\" />";
+        $expected = "<meta name=\"twitter:images0\" content=\"sayajin.png\">";
+        $expected .= "<meta name=\"twitter:images1\" content=\"namekusei.png\">";
 
         $this->setRightAssertion($expected);
     }
@@ -94,7 +94,7 @@ class TwitterCardsTest extends BaseTest
     {
         $this->twitterCards->setImage('sayajin.png');
 
-        $expected = "<meta name=\"twitter:image\" content=\"sayajin.png\" />";
+        $expected = "<meta name=\"twitter:image\" content=\"sayajin.png\">";
 
         $this->setRightAssertion($expected);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -

The w3c validator recently produces warnings, if you use the self-closing tag syntax. 