### PR TITLE
Preload links & Custom Tags

### DIFF
--- a/src/SEOTools/Contracts/MetaTags.php
+++ b/src/SEOTools/Contracts/MetaTags.php
@@ -142,6 +142,25 @@ interface MetaTags
     public function addMeta($meta, $value = null, $name = 'name');
 
     /**
+     * Add a preload link meta tag.
+     *
+     * @param string $href
+     * @param string $as
+     *
+     * @return static
+     */
+    public function addPreload($href, $as);
+
+    /**
+     * Add a custom meta tag.
+     *
+     * @param string|array $meta
+     *
+     * @return static
+     */
+    public function addCustom($meta);
+
+    /**
      * Sets the canonical URL.
      *
      * @param string $url

--- a/src/SEOTools/Facades/SEOMeta.php
+++ b/src/SEOTools/Facades/SEOMeta.php
@@ -18,6 +18,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Artesaos\SEOTools\Contracts\MetaTags addKeyword(string $keyword)
  * @method static \Artesaos\SEOTools\Contracts\MetaTags removeMeta(string $key)
  * @method static \Artesaos\SEOTools\Contracts\MetaTags addMeta(array|string $meta, string|null $value = null, string $name = 'name')
+ * @method static \Artesaos\SEOTools\Contracts\MetaTags addPreload(string $href, string $as)
+ * @method static \Artesaos\SEOTools\Contracts\MetaTags addCustom(array|string $meta)
  * @method static \Artesaos\SEOTools\Contracts\MetaTags setCanonical(string $url)
  * @method static \Artesaos\SEOTools\Contracts\MetaTags setPrev(string $url)
  * @method static \Artesaos\SEOTools\Contracts\MetaTags setNext(string $url)

--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -63,6 +63,20 @@ class SEOMeta implements MetaTagsContract
     protected $metatags = [];
 
     /**
+     * The preload links meta.
+     *
+     * @var string
+     */
+    protected $preloads = [];
+
+    /**
+     * The custom meta tags.
+     *
+     * @var string
+     */
+    protected $custom = [];
+
+    /**
      * The canonical URL.
      *
      * @var string
@@ -142,6 +156,8 @@ class SEOMeta implements MetaTagsContract
         $description = $this->getDescription();
         $keywords = $this->getKeywords();
         $metatags = $this->getMetatags();
+        $preloads = $this->getPreloads();
+        $custom = $this->getCustoms();
         $canonical = $this->getCanonical();
         $amphtml = $this->getAmpHtml();
         $prev = $this->getPrev();
@@ -179,6 +195,22 @@ class SEOMeta implements MetaTagsContract
             }
 
             $html[] = "<meta {$name}=\"{$key}\" content=\"{$content}\">";
+        }
+
+        foreach ($preloads as $preload) {
+            $href = $preload[0];
+            $as = $preload[1];
+
+            // if $href is empty jump to next
+            if (empty($href)) {
+                continue;
+            }
+
+            $html[] = "<link rel=\"preload\" href=\"{$href}\" as=\"{$as}\" />";
+        }
+
+        foreach ($custom as $meta) {
+            $html[] = $meta;
         }
 
         if ($canonical) {
@@ -326,6 +358,28 @@ class SEOMeta implements MetaTagsContract
     /**
      * {@inheritdoc}
      */
+    public function addPreload($href, $as)
+    {
+
+        $this->preloads[] = [$href, $as];
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addCustom($meta)
+    {
+
+        $this->preloads[] = $meta;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setCanonical($url)
     {
         $this->canonical = $url;
@@ -451,6 +505,26 @@ class SEOMeta implements MetaTagsContract
     public function getMetatags()
     {
         return $this->metatags;
+    }
+
+    /**
+     * Get preload links.
+     *
+     * @return string
+     */
+    public function getPreloads()
+    {
+        return $this->preloads;
+    }
+
+    /**
+     * Get custom meta.
+     *
+     * @return string
+     */
+    public function getCustoms()
+    {
+        return $this->custom;
     }
 
     /**

--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -372,7 +372,7 @@ class SEOMeta implements MetaTagsContract
     public function addCustom($meta)
     {
 
-        $this->preloads[] = $meta;
+        $this->custom[] = $meta;
 
         return $this;
     }


### PR DESCRIPTION
Added support for preload links:
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload

Also, to have the ability to add any other meta tag that is not yet supported i added a custom  array that takes a raw html tag and adds it in the header.