### PR TITLE
PHPUnit 10 - adjustments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,4 +42,4 @@ jobs:
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         verbose="true"
+    backupStaticAttributes="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
 >
     <testsuites>
         <testsuite name="SEOTools Test Suite">
@@ -21,10 +17,10 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="coverage-php" target="build/coverage.serialized"/>
+        <log type="tap" target="build/report.tap" />
+        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true" />
+        <log type="coverage-text" target="build/coverage.txt" />
+        <log type="coverage-clover" target="build/logs/clover.xml" />
+        <log type="coverage-php" target="build/coverage.serialized" />
     </logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-    backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"
     colors="true"
     processIsolation="false"
@@ -11,11 +10,4 @@
             <directory suffix=".php">./tests</directory>
         </testsuite>
     </testsuites>
-    <logging>
-        <log type="tap" target="build/report.tap" />
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true" />
-        <log type="coverage-text" target="build/coverage.txt" />
-        <log type="coverage-clover" target="build/logs/clover.xml" />
-        <log type="coverage-php" target="build/coverage.serialized" />
-    </logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,11 +11,6 @@
             <directory suffix=".php">./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
     <logging>
         <log type="tap" target="build/report.tap" />
         <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true" />

--- a/tests/SEOTools/BaseTest.php
+++ b/tests/SEOTools/BaseTest.php
@@ -9,7 +9,7 @@ use Orchestra\Testbench\TestCase;
 /**
  * Class BaseTest.
  */
-abstract class BaseTest extends TestCase
+class BaseTest extends TestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/SEOTools/SEOMetaTest.php
+++ b/tests/SEOTools/SEOMetaTest.php
@@ -168,7 +168,7 @@ class SEOMetaTest extends BaseTest
         $this->assertEquals($canonical, $this->seoMeta->getCanonical());
     }
 
-    public function dataTestUrls()
+    public static function dataTestUrls()
     {
         return [
             ['http://localhost/hello/world', 'http://localhost/hello/world'],

--- a/tests/SEOTools/SEOToolsServiceProviderTest.php
+++ b/tests/SEOTools/SEOToolsServiceProviderTest.php
@@ -26,7 +26,7 @@ class SEOToolsServiceProviderTest extends BaseTest
     /**
      * @return array
      */
-    public function bindsListProvider()
+    public static function bindsListProvider()
     {
         return [
             [

--- a/tests/SEOTools/Traits/SeoToolsTraitTest.php
+++ b/tests/SEOTools/Traits/SeoToolsTraitTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace Artesaos\SEOTools\Tests;
+namespace Artesaos\SEOTools\Tests\Traits;
 
 use Artesaos\SEOTools\Contracts\SEOTools;
 use Artesaos\SEOTools\Tests\stubs\SeoToolsTraitStub;
 use Mockery as m;
+
 /**
  * Class SeoToolsTraitTest.
  */

--- a/tests/SEOTools/Traits/SeoToolsTraitTest.php
+++ b/tests/SEOTools/Traits/SeoToolsTraitTest.php
@@ -4,6 +4,7 @@ namespace Artesaos\SEOTools\Tests\Traits;
 
 use Artesaos\SEOTools\Contracts\SEOTools;
 use Artesaos\SEOTools\Tests\stubs\SeoToolsTraitStub;
+use Artesaos\SEOTools\Tests\BaseTest;
 use Mockery as m;
 
 /**

--- a/tests/SEOTools/stubs/SeoToolsTraitStub.php
+++ b/tests/SEOTools/stubs/SeoToolsTraitStub.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Artesaos\SEOTools\Tests\stubs;
+
 use Artesaos\SEOTools\Traits\SEOTools;
 
 /**


### PR DESCRIPTION
PHPUnit 10 dropped support for the verbose flag; resulting in failure of the automated Github tests.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | 