### PR TITLE
Temp Fix - PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
   },
   "require-dev": {
     "orchestra/testbench": "~3.8.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
-    "phpspec/phpspec": "~5.1.1 || ^6.0 || ^7.0"
+    "phpspec/phpspec": "~5.1.1 || ^6.0 || ^7.0",
+    "phpunit/phpunit": "^9.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Pin PHPUnit to version 9; to make sure the automated tests remain operational.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 