### PR TITLE
feat: Allow to set alternate language(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,8 @@ SEOMeta::addKeyword($keyword);
 SEOMeta::addMeta($meta, $value = null, $name = 'name');
 SEOMeta::addAlternateLanguage($lang, $url);
 SEOMeta::addAlternateLanguages(array $languages);
+SEOMeta::setAlternateLanguage($lang, $url);
+SEOMeta::setAlternateLanguages(array $languages);
 SEOMeta::setTitleSeparator($separator);
 SEOMeta::setTitle($title);
 SEOMeta::setTitleDefault($default);

--- a/src/SEOTools/Contracts/MetaTags.php
+++ b/src/SEOTools/Contracts/MetaTags.php
@@ -188,6 +188,25 @@ interface MetaTags
     public function addAlternateLanguages(array $languages);
 
     /**
+     * Set an alternate language.
+     *
+     * @param string $lang language code in format ISO 639-1
+     * @param string $url
+     *
+     * @return static
+     */
+    public function setAlternateLanguage($lang, $url);
+
+    /**
+     * Set alternate languages.
+     *
+     * @param array $languages
+     *
+     * @return static
+     */
+    public function setAlternateLanguages(array $languages);
+
+    /**
      * Get the title formatted for display.
      *
      * @return string

--- a/src/SEOTools/Facades/SEOMeta.php
+++ b/src/SEOTools/Facades/SEOMeta.php
@@ -23,6 +23,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Artesaos\SEOTools\Contracts\MetaTags setNext(string $url)
  * @method static \Artesaos\SEOTools\Contracts\MetaTags addAlternateLanguage(string $lang, string $url)
  * @method static \Artesaos\SEOTools\Contracts\MetaTags addAlternateLanguages(array $languages)
+ * @method static \Artesaos\SEOTools\Contracts\MetaTags setAlternateLanguage(string $lang, string $url)
+ * @method static \Artesaos\SEOTools\Contracts\MetaTags setAlternateLanguages(array $languages)
  * @method static string getTitle()
  * @method static string getTitleSession()
  * @method static string getTitleSeparator()

--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -198,7 +198,9 @@ class SEOMeta implements MetaTagsContract
         }
 
         foreach ($languages as $lang) {
-            $html[] = "<link rel=\"alternate\" hreflang=\"{$lang['lang']}\" href=\"{$lang['url']}\">";
+            if (!empty($lang['lang'] && !empty($lang['url']))) {
+                $html[] = "<link rel=\"alternate\" hreflang=\"{$lang['lang']}\" href=\"{$lang['url']}\">";
+            }
         }
 
         if ($robots) {
@@ -383,6 +385,32 @@ class SEOMeta implements MetaTagsContract
     public function addAlternateLanguages(array $languages)
     {
         $this->alternateLanguages = array_merge($this->alternateLanguages, $languages);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAlternateLanguage($lang, $url)
+    {
+        // Remove language if already existing
+        $this->alternateLanguages = array_filter($this->alternateLanguages, function ($arr) use ($lang) {
+            return $arr['lang'] !== $lang;
+        });
+
+        // Append (updated) language
+        $this->alternateLanguages[] = ['lang' => $lang, 'url' => $url];
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAlternateLanguages(array $languages)
+    {
+        $this->alternateLanguages = $languages;
 
         return $this;
     }

--- a/tests/SEOTools/SEOMetaTest.php
+++ b/tests/SEOTools/SEOMetaTest.php
@@ -251,7 +251,7 @@ class SEOMetaTest extends BaseTest
         $this->assertEquals($prev, $this->seoMeta->getPrev());
     }
 
-    public function test_set_alternate_languages()
+    public function test_add_alternate_languages()
     {
         $fullHeader = "<title>It's Over 9000!</title>";
         $fullHeader .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
@@ -268,6 +268,70 @@ class SEOMetaTest extends BaseTest
         $this->seoMeta->addAlternateLanguages($expectedLangs);
 
         $this->assertEquals(array_merge($expectedLangs, $expectedLangs), $this->seoMeta->getAlternateLanguages());
+    }
+
+    public function test_set_alternate_languages()
+    {
+        $fullHeader = "<title>It's Over 9000!</title>";
+        $fullHeader .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
+        $fullHeader .= "<link rel=\"alternate\" hreflang=\"en\" href=\"http://domain.com\">";
+        $lang = 'en';
+        $langUrl = 'http://domain.com';
+
+        $expectedLangs = [['lang' => $lang, 'url' => $langUrl]];
+        $this->seoMeta->setAlternateLanguage($lang, $langUrl);
+
+        $this->setRightAssertion($fullHeader);
+        $this->assertEquals($expectedLangs, $this->seoMeta->getAlternateLanguages());
+
+        $this->seoMeta->setAlternateLanguages($expectedLangs);
+
+        $this->assertEquals($expectedLangs, $this->seoMeta->getAlternateLanguages());
+    }
+
+    public function test_set_override_alternate_language()
+    {
+        $fullHeader = "<title>It's Over 9000!</title>";
+        $fullHeader .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
+        $fullHeader .= "<link rel=\"alternate\" hreflang=\"en\" href=\"http://domain.test\">";
+        $lang = 'en';
+        $langUrl = 'http://domain.com';
+        $langUrlOverridden = 'http://domain.test';
+
+        $expectedLangs = [['lang' => $lang, 'url' => $langUrl]];
+        $expectedLangsOverridden = [['lang' => $lang, 'url' => $langUrlOverridden]];
+
+        $this->seoMeta->setAlternateLanguage($lang, $langUrl);
+        $this->assertEquals($expectedLangs, $this->seoMeta->getAlternateLanguages());
+
+        $this->seoMeta->setAlternateLanguage($lang, $langUrlOverridden);
+        $this->setRightAssertion($fullHeader);
+        $this->assertEquals($expectedLangsOverridden, $this->seoMeta->getAlternateLanguages());
+    }
+
+    public function test_remove_alternate_language()
+    {
+        $fullHeader = "<title>It's Over 9000!</title>";
+        $fullHeader .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
+        $lang = 'en';
+        $langUrl = 'http://domain.com';
+
+        $expectedLangs = [['lang' => $lang, 'url' => false]];
+
+        $this->seoMeta->setAlternateLanguage($lang, $langUrl);
+        $this->seoMeta->setAlternateLanguage($lang, false);
+        $this->setRightAssertion($fullHeader);
+        $this->assertEquals($expectedLangs, $this->seoMeta->getAlternateLanguages());
+    }
+
+    public function test_remove_alternate_languages()
+    {
+        $fullHeader = "<title>It's Over 9000!</title>";
+        $fullHeader .= "<meta name=\"description\" content=\"For those who helped create the Genki Dama\">";
+
+        $this->seoMeta->setAlternateLanguages([]);
+        $this->setRightAssertion($fullHeader);
+        $this->assertEquals([], $this->seoMeta->getAlternateLanguages());
     }
 
     public function test_set_reset()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️

Hi, thank you for the useful package!

It almost fits my requirements fully, except one case:
For a multi-language site all alternate language links are generated automatically as they all have the same structured URL. However, if an localised version of the site does not exist or if the originally requested page does not exist either, I want to be able to remove the alternate language meta links. So that crawlers not unnecessary crawl those 404 page(s) and reducing the crawling budget on top. For the other properties in this package that's possible by setting the value to false, however this does not work for the alternate languages (append only currently, no filtering of falsy values during tag generation). Therefore, I added an possibility to set alternate language(s) and filter out falsy values thereof. Documentation and tests are provided too for this added functionality.

Looking forward to your feedback or even better, a merge and release with the feature. Thanks!
