### PR TITLE
Update README.md - Package discovery support for Laravel 11.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ composer require artesaos/seotools
 
 You need to update your application configuration in order to register the package so it can be loaded by Laravel, just update your `config/app.php` file adding the following code at the end of your `'providers'` section:
 
+> **Note**: If you are using Laravel 11.x, you will have to update `bootstrap/providers.php` instead. [Package Discovery](https://laravel.com/docs/11.x/packages#package-discovery).
+
 > `config/app.php`
 
 ```php

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ composer require artesaos/seotools
 
 You need to update your application configuration in order to register the package so it can be loaded by Laravel, just update your `config/app.php` file adding the following code at the end of your `'providers'` section:
 
-> **Note**: If you are using Laravel 11.x, you will have to update `bootstrap/providers.php` instead. [Package Discovery](https://laravel.com/docs/11.x/packages#package-discovery).
+> **Note**: If you are using Laravel 11+, you will have to update `bootstrap/providers.php` instead. [Package Discovery](https://laravel.com/docs/12.x/packages#package-discovery).
 
 > `config/app.php`
 


### PR DESCRIPTION
Laravel's new version, 11.x, has moved package setup to `bootstrap/providers.php`.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any