### PR TITLE
feat: add OpenGraph::setImage for adding images and remove old ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ use Artesaos\SEOTools\Facades\OpenGraph;
 OpenGraph::addProperty($key, $value); // value can be string or array
 OpenGraph::addImage($url); // add image url
 OpenGraph::addImages($url); // add an array of url images
+OpenGraph::setImage($url); // define image (remove all images and set new image)
 OpenGraph::setTitle($title); // define title
 OpenGraph::setDescription($description);  // define description
 OpenGraph::setUrl($url); // define url

--- a/src/SEOTools/Facades/OpenGraph.php
+++ b/src/SEOTools/Facades/OpenGraph.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Artesaos\SEOTools\Contracts\OpenGraph removeProperty(string $key)
  * @method static \Artesaos\SEOTools\Contracts\OpenGraph addImage(string $url, array $attributes = [])
  * @method static \Artesaos\SEOTools\Contracts\OpenGraph addImages(array $urls)
+ * @method static \Artesaos\SEOTools\Contracts\OpenGraph setImage(string $url, array $attributes = [])
  * @method static \Artesaos\SEOTools\Contracts\OpenGraph setTitle(string $title)
  * @method static \Artesaos\SEOTools\Contracts\OpenGraph setDescription(string $description)
  * @method static \Artesaos\SEOTools\Contracts\OpenGraph setUrl(string $url)

--- a/src/SEOTools/OpenGraph.php
+++ b/src/SEOTools/OpenGraph.php
@@ -841,4 +841,19 @@ class OpenGraph implements OpenGraphContract
     {
         return $this->addProperty('site_name', $name);
     }
+
+    /**
+     * Remove all images and set new image.
+     *
+     * @param string $url
+     * @param array  $attributes
+     *
+     * @return static
+     */
+    public function setImage($source = null, $attributes = [])
+    {
+        $this->images = [];
+
+        return $this->addImage($source, $attributes);
+    }
 }

--- a/tests/SEOTools/OpenGraphTest.php
+++ b/tests/SEOTools/OpenGraphTest.php
@@ -59,6 +59,27 @@ class OpenGraphTest extends BaseTest
         $this->setRightAssertion($expected);
     }
 
+    public function test_add_image_and_add_images_append_new_images()
+    {
+        $this->openGraphs->addImages(['image1.png']);
+        $this->openGraphs->addImage('image2.png');
+
+        $expected = '<meta property="og:title" content="Over 9000 Thousand!"><meta property="og:description" content="For those who helped create the Genki Dama"><meta property="og:image" content="image1.png"><meta property="og:image" content="image2.png">';
+
+        $this->setRightAssertion($expected); 
+    }
+
+    public function test_set_image_remove_old_images_and_add_new()
+    {
+        $this->openGraphs->addImages(['image1.png']);
+        $this->openGraphs->addImage('image2.png');
+        $this->openGraphs->setImage('image3.png');
+
+        $expected = '<meta property="og:title" content="Over 9000 Thousand!"><meta property="og:description" content="For those who helped create the Genki Dama"><meta property="og:image" content="image3.png">';
+
+        $this->setRightAssertion($expected); 
+    }
+
     /**
      * @param $expectedString
      */


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 


I have added `setImage` to OpenGraph class because sometimes I want to set an open graph image and remove default image.

I have not found a way to do that until I added this pull request.

by the way, the `setImage` method is in `TwitterCards`, and in  `JsonLd` and `JsonLdMulti` it is `setImages`.


I have added the test for this addition with one line in readme.