### PR TITLE
Add missing public methods to MetaTags contract

### DIFF
--- a/src/SEOTools/Contracts/MetaTags.php
+++ b/src/SEOTools/Contracts/MetaTags.php
@@ -151,6 +151,15 @@ interface MetaTags
     public function setCanonical($url);
 
     /**
+     * Sets the AMP html URL.
+     *
+     * @param string $url
+     *
+     * @return static
+     */
+    public function setAmpHtml($url);
+
+    /**
      * Sets the prev URL.
      *
      * @param string $url
@@ -207,6 +216,15 @@ interface MetaTags
     public function setAlternateLanguages(array $languages);
 
     /**
+     * Sets the meta robots tag.
+     *
+     * @param string $robots
+     *
+     * @return static
+     */
+    public function setRobots($robots);
+
+    /**
      * Get the title formatted for display.
      *
      * @return string
@@ -254,6 +272,13 @@ interface MetaTags
      * @return string
      */
     public function getCanonical();
+
+    /**
+     * Get the AMP html URL.
+     *
+     * @return string
+     */
+    public function getAmpHtml();
 
     /**
      * Get the prev URL.

--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -336,11 +336,7 @@ class SEOMeta implements MetaTagsContract
     }
 
     /**
-     * Sets the AMP html URL.
-     *
-     * @param string $url
-     *
-     * @return MetaTagsContract
+     * {@inheritdoc}
      */
     public function setAmpHtml($url)
     {
@@ -416,11 +412,7 @@ class SEOMeta implements MetaTagsContract
     }
 
     /**
-     * Sets the meta robots.
-     *
-     * @param string $robots
-     *
-     * @return MetaTagsContract
+     * {@inheritDoc}
      */
     public function setRobots($robots)
     {
@@ -514,9 +506,7 @@ class SEOMeta implements MetaTagsContract
     }
 
     /**
-     * Get the AMP html URL.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getAmpHtml()
     {


### PR DESCRIPTION
This fixes static analysis errors where e.g. PHPStan complains about missing methods when using setRobots()

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 