### PR TITLE
Correct operator precedence in alternate languages validation

### DIFF
--- a/src/SEOTools/SEOMeta.php
+++ b/src/SEOTools/SEOMeta.php
@@ -198,7 +198,7 @@ class SEOMeta implements MetaTagsContract
         }
 
         foreach ($languages as $lang) {
-            if (!empty($lang['lang'] && !empty($lang['url']))) {
+            if (!empty($lang['lang']) && !empty($lang['url'])) {
                 $html[] = "<link rel=\"alternate\" hreflang=\"{$lang['lang']}\" href=\"{$lang['url']}\">";
             }
         }


### PR DESCRIPTION
Fix operator precedence bug in alternate languages validation

The condition on line 201 had incorrect parentheses placement, causing  only the last alternate language to be rendered. Fixed by properly  separating the two !empty() checks with the AND operator.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | -