### PR TITLE
Set minimum-stability to stable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: ['10.*', '11.*', '12.*']
+        laravel: ['10.*', '11.*', '12.*', '13.*']
         dependency-version: [prefer-stable]
         include:
           - laravel: 10.*
@@ -21,10 +21,14 @@ jobs:
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
         exclude:
           - php: 8.1
             laravel: 11.*
           - laravel: 12.*
+            php: 8.1
+          - laravel: 13.*
             php: 8.1
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,8 @@ jobs:
             php: 8.1
           - laravel: 13.*
             php: 8.1
+          - laravel: 13.*
+            php: 8.2
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "illuminate/config": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/support": "^10.0 || ^11.0 || ^12.0"
+        "illuminate/config": "^10.0 || ^11.0 || ^12.0 || ^13.0",
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
+        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0 || ^11.0",
         "phpunit/phpunit": "^9.0 || ^10.0 || ^11.5.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,5 @@
             }
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "minimum-stability": "stable"
 }


### PR DESCRIPTION
## Summary

- Changes `minimum-stability` from `"dev"` to `"stable"` in composer.json
- Removes the now redundant `prefer-stable: true` option
- Fixes the package showing as unstable/beta on Packagist

All dependencies already use stable version constraints, so `"dev"` stability was unnecessary and caused Packagist to flag the package as unstable.