### PR TITLE
Escape JSON-LD output for script contexts

### DIFF
--- a/src/SEOTools/JsonLd.php
+++ b/src/SEOTools/JsonLd.php
@@ -11,6 +11,13 @@ use Artesaos\SEOTools\Contracts\JsonLd as JsonLdContract;
  */
 class JsonLd implements JsonLdContract
 {
+    private const JSON_ENCODE_OPTIONS = JSON_UNESCAPED_UNICODE
+        | JSON_UNESCAPED_SLASHES
+        | JSON_HEX_TAG
+        | JSON_HEX_AMP
+        | JSON_HEX_APOS
+        | JSON_HEX_QUOT;
+
     /**
      * @var array
      */
@@ -94,7 +101,7 @@ class JsonLd implements JsonLdContract
             $this->convertToArray()
         );
 
-        return '<script type="application/ld+json">' . json_encode($generated, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . '</script>';
+        return '<script type="application/ld+json">' . json_encode($generated, self::JSON_ENCODE_OPTIONS) . '</script>';
     }
 
     /**

--- a/tests/SEOTools/BaseTest.php
+++ b/tests/SEOTools/BaseTest.php
@@ -40,4 +40,11 @@ class BaseTest extends TestCase
 
         return $dom;
     }
+
+    protected function jsonLdPayload($html)
+    {
+        preg_match('/<script type="application\/ld\+json">(.*?)<\/script>/s', $html, $matches);
+
+        return json_decode($matches[1], true);
+    }
 }

--- a/tests/SEOTools/BaseTest.php
+++ b/tests/SEOTools/BaseTest.php
@@ -41,10 +41,11 @@ class BaseTest extends TestCase
         return $dom;
     }
 
-    protected function jsonLdPayload($html)
+    protected function jsonLdPayload(string $html): array
     {
-        preg_match('/<script type="application\/ld\+json">(.*?)<\/script>/s', $html, $matches);
+        $matched = preg_match('/<script type="application\/ld\+json">(.*?)<\/script>/s', $html, $matches);
+        $this->assertSame(1, $matched, 'Expected to find a JSON-LD <script type="application/ld+json"> tag');
 
-        return json_decode($matches[1], true);
+        return json_decode($matches[1], true, 512, JSON_THROW_ON_ERROR);
     }
 }

--- a/tests/SEOTools/JsonLdMultiTest.php
+++ b/tests/SEOTools/JsonLdMultiTest.php
@@ -85,9 +85,21 @@ class JsonLdMultiTest extends BaseTest
 
         $this->jsonLdMulti->setDescription($description);
 
-        $expected = htmlspecialchars_decode('<html><head><script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"\"Foo bar\" -&gt; abc"}</script></head></html>');
+        $expected = '<html><head><script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"\u0022Foo bar\u0022 -\u003E abc"}</script></head></html>';
 
         $this->setRightAssertion($expected);
+    }
+
+    public function test_escapes_html_sensitive_characters_for_script_context()
+    {
+        $description = 'Safe text </script><script>alert("json-ld")</script> & \'quoted\'';
+
+        $this->jsonLdMulti->setDescription($description);
+
+        $html = $this->jsonLdMulti->generate();
+
+        $this->assertStringNotContainsString('</script><script>', $html);
+        $this->assertSame($description, $this->jsonLdPayload($html)['description']);
     }
 
     public function test_set_type()

--- a/tests/SEOTools/JsonLdTest.php
+++ b/tests/SEOTools/JsonLdTest.php
@@ -79,9 +79,21 @@ class JsonLdTest extends BaseTest
 
         $this->jsonLd->setDescription($description);
 
-        $expected = htmlspecialchars_decode('<html><head><script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"\"Foo bar\" -&gt; abc"}</script></head></html>');
+        $expected = '<html><head><script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Over 9000 Thousand!","description":"\u0022Foo bar\u0022 -\u003E abc"}</script></head></html>';
 
         $this->setRightAssertion($expected);
+    }
+
+    public function test_escapes_html_sensitive_characters_for_script_context()
+    {
+        $description = 'Safe text </script><script>alert("json-ld")</script> & \'quoted\'';
+
+        $this->jsonLd->setDescription($description);
+
+        $html = $this->jsonLd->generate();
+
+        $this->assertStringNotContainsString('</script><script>', $html);
+        $this->assertSame($description, $this->jsonLdPayload($html)['description']);
     }
 
     public function test_set_type()


### PR DESCRIPTION
## Summary

- Escape HTML-sensitive characters when generating JSON-LD script contents.
- Keep the existing `JSON_UNESCAPED_UNICODE` and `JSON_UNESCAPED_SLASHES` behavior.
- Add JsonLd and JsonLdMulti coverage to verify script delimiters are encoded while decoded JSON-LD data remains unchanged.

## Why

JSON-LD is emitted inside a `<script type="application/ld+json">` element, so values need to be safe for an HTML script context, not only valid JSON.

For example, a value such as:

```text
Safe text </script><script>alert("json-ld")</script>
```

can close the JSON-LD script element early if `<` and `>` are emitted directly. Encoding HTML-sensitive characters with the `JSON_HEX_*` flags keeps the value as inert JSON inside the original script tag while preserving the decoded JSON-LD value for consumers.

Closes #326.

## Testing

- `vendor/bin/phpunit tests/SEOTools/JsonLdTest.php tests/SEOTools/JsonLdMultiTest.php --colors=always`
- `vendor/bin/phpunit --colors=always`
